### PR TITLE
feat: Implement HTMX spinner and messages for login button

### DIFF
--- a/functions/api/user_login.js
+++ b/functions/api/user_login.js
@@ -1,0 +1,25 @@
+export async function onRequestPost(context) {
+  try {
+    // Get the request body as form data
+    const formData = await context.request.formData();
+    const email = formData.get('email');
+    const password = formData.get('pw');
+
+    // Placeholder authentication logic
+    if (password === 'password') {
+      return new Response('<p>Login successful! (Placeholder)</p>', {
+        headers: { 'Content-Type': 'text/html' },
+      });
+    } else {
+      return new Response('<p>Login failed. Please check your credentials. (Placeholder)</p>', {
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+  } catch (error) {
+    console.error('Login error:', error);
+    return new Response('<p>An unexpected error occurred.</p>', {
+      status: 500,
+      headers: { 'Content-Type': 'text/html' },
+    });
+  }
+}

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <script src="htmx_1.9.7.min.js"></script>
+    <style>
+        #login-result p {
+            padding: 10px;
+            border: 1px solid #ccc;
+            margin-top: 10px;
+            border-radius: 4px; /* Optional: for rounded corners */
+        }
+        .htmx-indicator {
+            display: none; /* Hidden by default */
+        }
+        /* Style for the spinner text when it's visible */
+        .htmx-indicator.htmx-request, .htmx-request .htmx-indicator {
+            display: inline-block; /* Shown during HTMX request */
+            font-style: italic;
+            /* Add any other desired spinner styling here, e.g., color */
+        }
+    </style>
+</head>
+<body>
+    <h1>Login</h1>
+    <form>
+        <div>
+            <label for="email">Email:</label>
+            <input type="email" id="email" name="email" placeholder="you@email.com" required>
+        </div>
+        <div>
+            <label for="pw">Password:</label>
+            <input type="password" id="pw" name="pw" placeholder="Password" required>
+        </div>
+        <button type="submit" hx-post="/api/user_login" hx-trigger="click" hx-include="[name='email'], [name='pw']" hx-target="#login-result">
+            Log In
+            <span class="htmx-indicator"> Loading...</span>
+        </button>
+    </form>
+    <div id="login-result"></div>
+</body>
+</html>


### PR DESCRIPTION
Implements HTMX enhancements for the login button in public/login.html:
- Changes the submit input to a button to accommodate a text-based spinner.
- The spinner ("Loading...") is displayed during form submission.
- Uses hx-indicator for spinner visibility, styled to be hidden by default.
- Server responses (success/error) are displayed in the #login-result div.

Adds a new placeholder API endpoint at functions/api/user_login.js:
- Simulates login success if password is "password".
- Returns HTML snippets for success or failure messages.

Includes basic CSS in public/login.html for styling the messages and the spinner.

Note: These changes are based on public/login.html from the cf-pages branch and the new API endpoint should be deployed with it. You reported page reload issues during preliminary testing; further investigation may be needed if this persists after deployment.