### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,5 +1,8 @@
 name: "CI: Prettier"
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/eustasy/puff-serverless/security/code-scanning/12](https://github.com/eustasy/puff-serverless/security/code-scanning/12)

In general, this problem is fixed by explicitly defining a `permissions` block for the workflow or for the specific job, so that the `GITHUB_TOKEN` is restricted to the least privileges needed. For a formatting/CI job that just checks out code and runs Prettier, read-only access to repository contents is sufficient.

The best minimal change here, without altering existing behavior, is to add `permissions: contents: read` at the workflow root (near the top of `.github/workflows/prettier.yml`). This will apply to all jobs (currently just `prettier`) that don’t override permissions and will ensure the token cannot perform write operations on the repo. No other steps, inputs, or actions need to change, and no imports or dependencies are required.

Concretely: in `.github/workflows/prettier.yml`, insert a `permissions:` block after the `name` (line 1) and before the `on:` block (line 3). This confines the `GITHUB_TOKEN` for this workflow to read-only contents while keeping the rest of the workflow identical.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
