### PR TITLE
Potential fix for code scanning alert no. 13: Checkout of untrusted code in trusted context

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
       - name: Prettier Action
         uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0 # v4.6
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/eustasy/puff-serverless/security/code-scanning/13](https://github.com/eustasy/puff-serverless/security/code-scanning/13)

In general, to fix this class of problem you should avoid explicitly checking out the pull request head (`github.head_ref` / `pull_request.head.sha`) in workflows that may have elevated privileges or access to secrets. Instead, let `actions/checkout` use its default behavior, which checks out the specific commit that triggered the workflow (`github.sha`). This keeps untrusted PR code confined to the least-privileged context appropriate for the event.

For this workflow, the best minimal fix without changing behavior is to remove the `with: ref: ${{ github.head_ref }}` configuration from the checkout step. For `pull_request` events, `actions/checkout` already checks out the pull request merge commit corresponding to `github.sha` by default, which is normally what you want for CI. For `push` and `schedule` events, it will similarly check out the triggering commit. That removes the explicit untrusted‑head pattern while preserving functionality.

Concretely, in `.github/workflows/prettier.yml`, edit the `Checkout` step under `jobs.prettier.steps` (lines 18–22). Delete the `with:` block entirely so that the step is simply `uses: actions/checkout@v6` with no explicit `ref`. No new imports, actions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
